### PR TITLE
Fix CSV header naming typos in qdrant_collection.py

### DIFF
--- a/src/flare_ai_rag/retriever/qdrant_collection.py
+++ b/src/flare_ai_rag/retriever/qdrant_collection.py
@@ -42,12 +42,12 @@ def generate_collection(
     for idx, (_, row) in enumerate(
         df_docs.iterrows(), start=1
     ):  # Using _ for unused variable
-        content = row["Contents"]
+        content = row["content"]
 
         if not isinstance(content, str):
             logger.warning(
                 "Skipping document due to missing or invalid content.",
-                filename=row["Filename"],
+                filename=row["file_name"],
             )
             continue
 
@@ -56,7 +56,7 @@ def generate_collection(
                 embedding_model=retriever_config.embedding_model,
                 task_type=EmbeddingTaskType.RETRIEVAL_DOCUMENT,
                 contents=content,
-                title=str(row["Filename"]),
+                title=str(row["file_name"]),
             )
         except google.api_core.exceptions.InvalidArgument as e:
             # Check if it's the known "Request payload size exceeds the limit" error
@@ -64,26 +64,26 @@ def generate_collection(
             if "400 Request payload size exceeds the limit" in str(e):
                 logger.warning(
                     "Skipping document due to size limit.",
-                    filename=row["Filename"],
+                    filename=row["file_name"],
                 )
                 continue
             # Log the full traceback for other InvalidArgument errors
             logger.exception(
                 "Error encoding document (InvalidArgument).",
-                filename=row["Filename"],
+                filename=row["file_name"],
             )
             continue
         except Exception:
             # Log the full traceback for any other errors
             logger.exception(
                 "Error encoding document (general).",
-                filename=row["Filename"],
+                filename=row["file_name"],
             )
             continue
 
         payload = {
-            "filename": row["Filename"],
-            "metadata": row["Metadata"],
+            "filename": row["file_name"],
+            "metadata": row["meta_data"],
             "text": content,
         }
 


### PR DESCRIPTION
Currently in `src/data/document.csv` the headers are `file_name,meta_data,content,last_updated` but in `qdrant_collection.py` the headers are accessed in upper-case, causing this `KeyError: 'Contents'` error:

<details>
<summary><code>docker run -p 80:80 -it --env-file .env flare-ai-rag</code> error</summary>
```shell
❯ docker run -p 80:80 -it --env-file .env flare-ai-rag
2025-03-08 01:34:43,278 INFO Set uid to user 0 succeeded
2025-03-08 01:34:43,279 INFO supervisord started with pid 1
2025-03-08 01:34:44,282 INFO spawned: 'backend' with pid 7
2025-03-08 01:34:44,283 INFO spawned: 'nginx' with pid 8
Waiting for Qdrant to initialize...
Qdrant is not ready yet, waiting...
           _                 _    
  __ _  __| |_ __ __ _ _ __ | |_  
 / _` |/ _` | '__/ _` | '_ \| __| 
| (_| | (_| | | | (_| | | | | |_  
 \__, |\__,_|_|  \__,_|_| |_|\__| 
    |_|                           

Version: 1.13.4, build: 7abc6843
Access web UI at http://localhost:6333/dashboard

2025-03-08T01:34:44.384132Z  WARN qdrant::settings: Config file not found: config/config    
2025-03-08T01:34:44.385131Z  WARN qdrant::settings: Config file not found: config/development    
2025-03-08T01:34:44.386114Z  WARN qdrant: Bootstrap URI is the same as this peer URI. Consider this peer as a first in a new deployment.    
2025-03-08T01:34:44.386312Z  INFO storage::content_manager::consensus::persistent: Initializing new raft state at ./storage/raft_state.json    
2025-03-08T01:34:44.414194Z  INFO qdrant: Distributed mode disabled    
2025-03-08T01:34:44.415504Z  INFO qdrant: Telemetry reporting enabled, id: c463fba3-b6a5-4772-bb58-47f4a21cb3d1    
2025-03-08T01:34:44.417295Z  INFO qdrant: Inference service is not configured.    
2025-03-08T01:34:44.424502Z  WARN qdrant::actix::web_ui: Static content folder for Web UI './static' does not exist    
2025-03-08T01:34:44.425190Z  INFO qdrant::actix: TLS disabled for REST API    
2025-03-08T01:34:44.427649Z  INFO qdrant::actix: Qdrant HTTP listening on 6333    
2025-03-08T01:34:44.429284Z  INFO actix_server::builder: Starting 11 workers
2025-03-08T01:34:44.429937Z  INFO actix_server::server: Actix runtime found; starting in Actix runtime
2025-03-08T01:34:44.443941Z  INFO qdrant::tonic: Qdrant gRPC listening on 6334    
2025-03-08T01:34:44.443962Z  INFO qdrant::tonic: TLS disabled for gRPC API    
2025-03-08 01:34:45,447 INFO success: backend entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-03-08 01:34:45,447 INFO success: nginx entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-03-08T01:34:54.317605Z  INFO actix_web::middleware::logger: 127.0.0.1 "GET /collections HTTP/1.1" 200 62 "-" "curl/7.88.1" 0.013454    
Qdrant is up and running!
   Building flare-ai-rag @ file:///app
Downloading ruff (9.9MiB)
Downloading pyright (5.4MiB)
 Downloaded pyright
      Built flare-ai-rag @ file:///app
 Downloaded ruff
Uninstalled 1 package in 6ms
Installed 4 packages in 48ms
2025-03-08 01:34:58 [debug    ] Settings have been initialized. settings={'simulate_attestation': False, 'gemini_api_key': 'AIzaSyAoC3BoOE8xNV84l_i-jfCENxnwF6huvxo', 'open_router_base_url': 'https://openrouter.ai/api/v1', 'open_router_api_key': '', 'cors_origins': ['*'], 'data_path': PosixPath('/app/src/data'), 'input_path': PosixPath('/app/src/flare_ai_rag')}
2025-03-08 01:34:58 [info     ] Loaded CSV Data.               num_rows=129
2025-03-08 01:34:58 [info     ] Setting up Qdrant client...
2025-03-08 01:34:58 [info     ] Qdrant client has been set up.
2025-03-08T01:34:58.837789Z  INFO storage::content_manager::toc::collection_meta_ops: Deleting collection docs_collection    
2025-03-08T01:34:58.838467Z  INFO actix_web::middleware::logger: 127.0.0.1 "DELETE /collections/docs_collection HTTP/1.1" 200 72 "-" "qdrant-client/1.13.3 python/3.12.9" 0.002207    
2025-03-08T01:34:58.843230Z  INFO storage::content_manager::toc::collection_meta_ops: Creating collection docs_collection    
2025-03-08T01:34:59.508920Z  INFO actix_web::middleware::logger: 127.0.0.1 "PUT /collections/docs_collection HTTP/1.1" 200 71 "-" "qdrant-client/1.13.3 python/3.12.9" 0.669334    
2025-03-08 01:34:59 [info     ] Created the collection.        collection_name=docs_collection
Traceback (most recent call last):
  File "/app/.venv/lib/python3.12/site-packages/pandas/core/indexes/base.py", line 3805, in get_loc
    return self._engine.get_loc(casted_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "index.pyx", line 167, in pandas._libs.index.IndexEngine.get_loc
  File "index.pyx", line 196, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 7081, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 7089, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'Contents'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/.venv/bin/start-backend", line 4, in <module>
    from flare_ai_rag.main import start
  File "/app/src/flare_ai_rag/main.py", line 160, in <module>
    app = create_app()
          ^^^^^^^^^^^^
  File "/app/src/flare_ai_rag/main.py", line 140, in create_app
    retriever_component = setup_retriever(qdrant_client, input_config, df_docs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/flare_ai_rag/main.py", line 57, in setup_retriever
    generate_collection(
  File "/app/src/flare_ai_rag/retriever/qdrant_collection.py", line 45, in generate_collection
    content = row["Contents"]
              ~~~^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/pandas/core/series.py", line 1121, in __getitem__
    return self._get_value(key)
           ^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/pandas/core/series.py", line 1237, in _get_value
    loc = self.index.get_loc(label)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/pandas/core/indexes/base.py", line 3812, in get_loc
    raise KeyError(key) from err
KeyError: 'Contents'
2025-03-08 01:35:00,513 WARN exited: backend (exit status 1; not expected)
...
```
</details>

and this error in the chat UI:

![image](https://github.com/user-attachments/assets/3b1684ec-0eb9-4b77-b8d6-8641ab9b0e65)



With my fixes, the chat UI now works!

![image](https://github.com/user-attachments/assets/ca2a76e0-9dbf-4467-87c6-8d8d475dcf58)

